### PR TITLE
Add additional config option to append a CI skip to commit messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ You can configure Boomper using the following key in your `.github/boomper.yml` 
 |`updates.[].pattern`|Required|The regular expression containing a single group, which will be used to match and update the version number in the file.|
 |`updates.[].branch`|Optional|The branch to update. Default is the repository's default branch (e.g. `master`).|
 |`branches`|Optional|The branches to listen for configuration updates to `.github/boomper.yml`. Useful if you want to test the app on a pull request branch. Default is `"master"`.|
+|`skipCi`|Optional|Appends `[ci skip]` to commit messages to prevent triggering additional CI builds. Default is `false`.|
 
 Boomper also supports [Probot Config](https://github.com/probot/probot-config), if you want to store your configuration files in a central repository.
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ You can configure Boomper using the following key in your `.github/boomper.yml` 
 |`updates.[].pattern`|Required|The regular expression containing a single group, which will be used to match and update the version number in the file.|
 |`updates.[].branch`|Optional|The branch to update. Default is the repository's default branch (e.g. `master`).|
 |`branches`|Optional|The branches to listen for configuration updates to `.github/boomper.yml`. Useful if you want to test the app on a pull request branch. Default is `"master"`.|
-|`skipCi`|Optional|Appends `[ci skip]` to commit messages to prevent triggering additional CI builds. Default is `false`.|
+|`skip-ci`|Optional|Appends `[ci skip]` to commit messages to prevent triggering additional CI builds. Default is `false`.|
 
 Boomper also supports [Probot Config](https://github.com/probot/probot-config), if you want to store your configuration files in a central repository.
 

--- a/lib/run.js
+++ b/lib/run.js
@@ -3,7 +3,7 @@ const compareVersions = require('compare-versions')
 const { decodeContent, encodeContent } = require('./base46')
 const patternReplace = require('./pattern-replace')
 
-const runUpdate = async ({ app, context, path, pattern, branch, release }) => {
+const runUpdate = async ({ app, context, path, pattern, branch, release, skipCi }) => {
   const version = release.tag_name
 
   if (!path || !pattern) {
@@ -20,9 +20,14 @@ const runUpdate = async ({ app, context, path, pattern, branch, release }) => {
     return
   }
 
+  let message = `Bump ${path} for ${version} release`
+  if (skipCi) {
+    message += ` [skip ci]`
+  }
+
   await context.github.repos.updateFile(context.repo({
     path,
-    message: `Bump ${path} for ${version} release`,
+    message,
     content: encodeContent(updatedContent),
     sha: contentResponse.data.sha,
     branch: branch
@@ -33,7 +38,7 @@ const runUpdate = async ({ app, context, path, pattern, branch, release }) => {
 
 module.exports = async ({ app, context, configName }) => {
   const config = await getConfig(context, configName) || {}
-  let { updates, branches } = config
+  let { updates, branches, skipCi } = config
 
   if (!branches) {
     branches = ['master']
@@ -73,6 +78,7 @@ module.exports = async ({ app, context, configName }) => {
       app,
       context,
       release,
+      skipCi,
       ...update
     })))
   }

--- a/lib/run.js
+++ b/lib/run.js
@@ -21,7 +21,7 @@ const runUpdate = async ({ context, path, pattern, branch, release, skipCi }) =>
 
   let message = `Bump ${path} for ${version} release`
   if (skipCi) {
-    message += ` [skip ci]`
+    message += ' [skip ci]'
   }
 
   await context.github.repos.createOrUpdateFileContents(context.repo({

--- a/lib/run.js
+++ b/lib/run.js
@@ -38,7 +38,8 @@ const runUpdate = async ({ app, context, path, pattern, branch, release, skipCi 
 
 module.exports = async ({ app, context, configName }) => {
   const config = await getConfig(context, configName) || {}
-  let { updates, branches, skipCi } = config
+  const skipCi = config['skip-ci']
+  let { updates, branches } = config
 
   if (!branches) {
     branches = ['master']

--- a/test/fixtures/config-with-skip-ci.yml
+++ b/test/fixtures/config-with-skip-ci.yml
@@ -1,4 +1,4 @@
 updates:
 - path: README.md
   pattern: https://download.com/(.*)/file.zip
-skipCi: true
+skip-ci: true

--- a/test/fixtures/config-with-skip-ci.yml
+++ b/test/fixtures/config-with-skip-ci.yml
@@ -1,0 +1,4 @@
+updates:
+- path: README.md
+  pattern: https://download.com/(.*)/file.zip
+skipCi: true

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -101,22 +101,29 @@ https://download.com/v1.0.0/file.zip`))
             const release = require('./fixtures/release').release
             const oldRelease = require('./fixtures/release-old-version').release
 
-            github.repos.getContent = fn()
-              .mockReturnValueOnce(mockConfig('config-with-skip-ci.yml'))
-              .mockReturnValueOnce(mockContent(`https://download.com/v0.0.1/file.zip`))
-
-            github.repos.getReleases = fn().mockReturnValueOnce(Promise.resolve({ data: [ oldRelease, release ] }))
-
-            await app.receive({ name: 'release', payload: require('./fixtures/release') })
-
-            const [ [ updateCall ] ] = github.repos.updateFile.mock.calls
-            expect(decodeContent(updateCall.content)).toBe(`https://download.com/v1.0.2/file.zip`)
-
-            expect(github.repos.updateFile).toBeCalledWith(
-              expect.objectContaining({
-                'message': 'Bump README.md for v1.0.2 release [skip ci]'
+            const mock = nock('https://api.github.com')
+              .get('/repos/toolmantim/boomper-test-project/contents/.github%2Fboomper.yml')
+              .reply(200, mockConfig('config-with-skip-ci.yml'))
+              .get('/repos/toolmantim/boomper-test-project/releases')
+              .reply(200, [oldRelease, release])
+              .get('/repos/toolmantim/boomper-test-project/contents/README.md')
+              .reply(200, mockContent(`
+  # Some project
+  https://download.com/v0.0.1/file.zip
+  https://download.com/v1.0.0/file.zip`))
+              .put('/repos/toolmantim/boomper-test-project/contents/README.md', (body) => {
+                expect(body).toEqual({
+                  content: 'CiAgIyBTb21lIHByb2plY3QKICBodHRwczovL2Rvd25sb2FkLmNvbS92MS4wLjIvZmlsZS56aXAKICBodHRwczovL2Rvd25sb2FkLmNvbS92MS4wLjIvZmlsZS56aXA=',
+                  message: 'Bump README.md for v1.0.2 release [skip ci]',
+                  sha: '3b54dab859e79dd0f2548039ababb44f33cae4ea'
+                })
+                return true
               })
-            )
+              .reply(201, {})
+
+            await probot.receive({ name: 'release', payload: require('./fixtures/release') })
+
+            expect(mock.activeMocks()).toStrictEqual([])
           })
         })
       })


### PR DESCRIPTION
If you specify multiple files, Boomper creates a commit for each file which can trigger a lot of redundant CI builds.

This allows specifying a config option to append a common CI skip annotation to the commit message. Defaults to `false` so it should be backwards compatible with existing installations.

Resolves #105 